### PR TITLE
Add `position` patching

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,13 @@ function toMDAST(tree) {
 }
 
 function h(node, type, props, children) {
+  var result;
   if (!children && ((typeof props === 'object' && 'length' in props) || typeof props === 'string')) {
     children = props;
     props = {};
   }
 
-  var result = augment(node, {type: type});
+  result = xtend({type: type}, props);
 
   if (typeof children === 'string') {
     result.value = children;
@@ -25,14 +26,14 @@ function h(node, type, props, children) {
     result.children = children;
   }
 
-  return xtend(result, props);
+  return augment(node, result);
 }
 
 /* `right` is the finalized MDAST node,
  * created from `left`, a HAST node */
 function augment(left, right) {
-  if (left.value) {
-    right.value = left.value;
+  if (left.position) {
+    right.position = left.position;
   }
 
   return right;

--- a/tests/index.js
+++ b/tests/index.js
@@ -42,6 +42,51 @@ test('core', function (t) {
     'should ignore unknown voids'
   );
 
+  var pos = {
+    left: {
+      line: 1,
+      column: 1,
+      offset: 0
+    },
+    right: {
+      line: 1,
+      column: 6,
+      offset: 5
+    }
+  };
+
+  t.deepEqual(
+    toMDAST({
+      type: 'root',
+      children: [{
+        type: 'element',
+        tagName: 'p',
+        properties: {},
+        children: [{
+          type: 'text',
+          value: 'Alpha',
+          position: pos
+        }],
+        position: pos
+      }],
+      position: pos
+    }),
+    {
+      type: 'root',
+      children: [{
+        type: 'paragraph',
+        children: [{
+          type: 'text',
+          value: 'Alpha',
+          position: pos
+        }],
+        position: pos
+      }],
+      position: pos
+    },
+    'should ignore unknown voids'
+  );
+
   t.end();
 });
 


### PR DESCRIPTION
`mdast-util-to-hast` uses the `augment` function to patch positions from MDAST to HAST, so the HAST nodes have positional information which links back to the input file.
Here I’ve re-enabled that, so we can keep positional info in place