### PR TITLE
Add option to collapse whitespace containing newlines to `\n` instead of ` `

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,16 @@
 
 module.exports = toMDAST;
 
-var minify = require('rehype-minify-whitespace')();
+var rehypeMinifyWhitespace = require('rehype-minify-whitespace');
 var xtend = require('xtend');
 var one = require('./lib/one');
 var handlers = require('./lib/handlers');
 
 function toMDAST(tree, options) {
   var settings = options || {};
+  var minify = rehypeMinifyWhitespace({
+    newlines: typeof settings.newlines === 'boolean' ? settings.newlines : false
+  });
 
   h.handlers = xtend(handlers, settings.handlers || {});
   h.augment = augment;

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,11 @@ Whether the given tree is a complete document.  If `document: true`,
 implicit paragraphs are added in the `root` node around inline MDAST nodes.
 Otherwise, inline MDAST nodes are wrapped when needed.
 
+###### `options.newlines`
+
+If `newlines: true`, collapses white-space containing newlines to `\n` instead
+of ` `. Default is `newlines: false`.
+
 ##### Returns
 
 [`MDASTNode`][mdast].

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Otherwise, inline MDAST nodes are wrapped when needed.
 ###### `options.newlines`
 
 If `newlines: true`, collapses white-space containing newlines to `\n` instead
-of ` `. Default is `newlines: false`.
+of ``.  Default is `newlines: false`.
 
 ##### Returns
 

--- a/test/index.js
+++ b/test/index.js
@@ -193,6 +193,40 @@ test('handlers option', function (t) {
   t.end();
 });
 
+test('newlines option', function (t) {
+  var options = {
+    newlines: true
+  };
+
+  t.deepEqual(
+    toMDAST({
+      type: 'root',
+      children: [{
+        type: 'element',
+        tagName: 'p',
+        properties: {},
+        children: [{
+          type: 'text',
+          value: 'Alpha\nBeta'
+        }]
+      }]
+    }, options),
+    {
+      type: 'root',
+      children: [{
+        type: 'paragraph',
+        children: [{
+          type: 'text',
+          value: 'Alpha\nBeta'
+        }]
+      }]
+    },
+    'should keep \\n'
+  );
+
+  t.end();
+});
+
 test('document', function (t) {
   var tree = u('root', [
     h('b', 'Importance'),


### PR DESCRIPTION
I need to convert custom markdown to html and convert back this html to original markdown, and carriage returns are useful to me. I made this small change and think it may be useful for someone else :)