### PR TITLE
Use `innerText` for code

### DIFF
--- a/lib/handlers/code.js
+++ b/lib/handlers/code.js
@@ -4,7 +4,7 @@ module.exports = code
 
 var is = require('hast-util-is-element')
 var has = require('hast-util-has-property')
-var toString = require('hast-util-to-string')
+var toText = require('hast-util-to-text')
 var trim = require('trim-trailing-lines')
 
 var prefix = 'language-'
@@ -43,5 +43,5 @@ function code(h, node) {
     }
   }
 
-  return h(node, 'code', {lang: lang || null, meta: null}, trim(toString(node)))
+  return h(node, 'code', {lang: lang || null, meta: null}, trim(toText(node)))
 }

--- a/lib/handlers/inline-code.js
+++ b/lib/handlers/inline-code.js
@@ -2,8 +2,8 @@
 
 module.exports = inlineCode
 
-var toString = require('hast-util-to-string')
+var toText = require('hast-util-to-text')
 
 function inlineCode(h, node) {
-  return h(node, 'inlineCode', toString(node))
+  return h(node, 'inlineCode', toText(node))
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "hast-util-has-property": "^1.0.0",
     "hast-util-is-element": "^1.0.0",
-    "hast-util-to-string": "^1.0.0",
+    "hast-util-to-text": "^1.0.0",
     "mdast-util-phrasing": "^1.0.0",
     "mdast-util-to-string": "^1.0.4",
     "rehype-minify-whitespace": "^2.0.3",

--- a/test/fixtures/br/index.html
+++ b/test/fixtures/br/index.html
@@ -1,1 +1,2 @@
 <p>alpha<br>bravo</p>
+<pre>charlie<br>delta</pre>

--- a/test/fixtures/br/index.md
+++ b/test/fixtures/br/index.md
@@ -1,2 +1,5 @@
 alpha··
 bravo
+
+    charlie
+    delta

--- a/test/fixtures/listing/index.md
+++ b/test/fixtures/listing/index.md
@@ -24,5 +24,7 @@ hotel(); india
 ```
 
 ```
-juliettkilo();lima
+juliett
+kilo();
+lima
 ```

--- a/test/fixtures/pre/index.md
+++ b/test/fixtures/pre/index.md
@@ -31,5 +31,7 @@ lima(); mike
 ```
 
 ```
-november oscar(); papa
+november·
+oscar();
+ papa
 ```


### PR DESCRIPTION
This PR swaps about [hast-util-to-string](https://github.com/rehypejs/rehype-minify/tree/master/packages/hast-util-to-string) (`textContent`) for [hast-util-to-text](https://github.com/syntax-tree/hast-util-to-text) (`innerText`).

`innerText` is a horrible horrible algorithm. I spent about a week creating it. It’s really hard to grasp and involves several specifications. Don’t use it in browsers, but it has the added benefit of being representing textual content better as it cares about the type of elements that are used.

Closes GH-39.