### PR TITLE
Add exports of `one` and `all`

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ import {one} from './lib/one.js'
 import {handlers} from './lib/handlers/index.js'
 import {own} from './lib/util/own.js'
 
+export {one} from './lib/one.js'
+export {all} from './lib/all.js'
+
 var block = convert(['heading', 'paragraph', 'root'])
 
 /**

--- a/readme.md
+++ b/readme.md
@@ -237,6 +237,18 @@ Yields:
 Some text with <svg viewBox="0 0 1 1" width="1" height="1"><rect fill="black" x="0" y="0" width="1" height="1"></rect></svg> a graphic… Wait is that a dead pixel?
 ```
 
+### `all(h, parent)`
+
+Helper function for writing custom handlers passed to `options.handlers`.
+Pass it `h` and a parent node (hast) and it will turn the node’s children into
+an array of transformed nodes (mdast).
+
+### `one(h, node, parent)`
+
+Helper function for writing custom handlers passed to `options.handlers`.
+Pass it `h`, a `node`, and its `parent` (hast) and it will turn `node` into
+mdast content.
+
 ## Security
 
 Use of `hast-util-to-mdast` can open you up to a

--- a/test/index.js
+++ b/test/index.js
@@ -18,9 +18,23 @@ import rehypeStringify from 'rehype-parse'
 import remarkStringify from 'remark-stringify'
 import assert from 'mdast-util-assert'
 import {removePosition} from 'unist-util-remove-position'
-import {toMdast} from '../index.js'
+import {one, all, toMdast} from '../index.js'
 
 var fixtures = path.join('test', 'fixtures')
+
+test('exports', function (t) {
+  t.assert(
+    one,
+    'should export `one`'
+  )
+
+  t.assert(
+    all,
+    'should export `all`'
+  )
+
+  t.end()
+})
 
 test('core', function (t) {
   t.deepEqual(


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Export `one` and `all`

<!--do not edit: pr-->
