### PR TITLE
Removes URL import

### DIFF
--- a/lib/util/resolve.js
+++ b/lib/util/resolve.js
@@ -2,8 +2,6 @@
  * @typedef {import('../types.js').H} H
  */
 
-import {URL} from 'node:url'
-
 /**
  * @param {H} h
  * @param {string|null|undefined} url


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Node 10+ provide `URL` as a global. Importing it from `url` (or `node:url`) is unnecessary and causes problems when importing `hast-util-to-mdast` inside a browser context (because you then have to polyfill `url`).

<!--do not edit: pr-->
