### PR TITLE
Remove use of `URL` from `node:url`

### DIFF
--- a/lib/util/resolve.js
+++ b/lib/util/resolve.js
@@ -2,8 +2,6 @@
  * @typedef {import('../types.js').H} H
  */
 
-import {URL} from 'node:url'
-
 /**
  * @param {H} h
  * @param {string|null|undefined} url

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "tape": "^5.0.0",
     "type-coverage": "^2.0.0",
-    "typescript": "^4.0.0",
+    "typescript": "~4.4.0",
     "unified": "^10.0.0",
     "unist-builder": "^3.0.0",
     "unist-util-remove-position": "^4.0.0",

--- a/test/fixtures/figure-figcaption/index.md
+++ b/test/fixtures/figure-figcaption/index.md
@@ -1,4 +1,4 @@
-![The Pulpit Rock](img\_pulpit.jpg)
+![The Pulpit Rock](img_pulpit.jpg)
 
 Fig1. - A view of the pulpit rock in Norway.
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Continuation from #70.

In v7, we can use this package in browser, but because of the `'node:url'` import in v8, browser support is no longer available. The initial dismissal of the issue #70 was due to typescript complain, this PR attempt to address that in hope that it get merged and browser support is re-enabled again.

#### Changelog

- Pinning TypeScript to v4.4.x as it is hanging the compiler, see https://github.com/microsoft/TypeScript/issues/46900
- Fix figure figcaption test case which is broken, somehow `\` was added to the filename, but i checked the html there's no such character. Feel free to correct me if i'm wrong.
- Remove `import {URL} from 'node:url'`, from my use case, typescript didn't complain, but if it ever complain, my solution is to introduce `DOM` to `libs` in `tsconfig`.

<!--do not edit: pr-->
