### PR TITLE
Fix typo in readme about output tree

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -321,7 +321,7 @@ based on [CommonMark][] but adds the strikethrough (`~like so~`) and tables
 
 The input syntax tree format is [hast][].
 Any HTML that can be represented in hast is accepted as input.
-The input syntax tree format is [mdast][].
+The output syntax tree format is [mdast][].
 When `<table>` elements, or `<del>`, `<s>`, and `<strike>` exist in the
 HTML, then the GFM nodes `table` and `delete` are used.
 This utility does not generate definitions or references, or syntax extensions


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Currently the "Syntax tree" section in the README says that hast is the input format and mdast is also the input format. it's not -- mdast is the output! This PR fixes that sentence.

<!--do not edit: pr-->
