### PR TITLE
Add support for inferring phrasing of embedded hast

### DIFF
--- a/lib/util/wrap.js
+++ b/lib/util/wrap.js
@@ -5,7 +5,18 @@
  */
 
 import extend from 'extend'
-import {phrasing} from 'mdast-util-phrasing'
+import {phrasing as hastPhrasing} from 'hast-util-phrasing';
+import {phrasing as mdastPhrasing} from 'mdast-util-phrasing'
+
+/**
+ * @param {MdastNode} node 
+ * @returns {boolean}
+ */
+function phrasing(node) {
+  return node.data && node.data.hName
+      ? hastPhrasing({type: 'element', tagName: node.data.hName, properties: {}, children: []})
+      : mdastPhrasing(node);
+}
 
 /**
  * @param {Array.<MdastNode>} nodes
@@ -80,7 +91,7 @@ function runs(nodes, onphrasing, onnonphrasing) {
 
     if (phrasing(node)) {
       if (!queue) queue = []
-      queue.push(node)
+      queue.push((/** @type {MdastPhrasingContent} */ (node)))
     } else {
       if (queue) {
         result = result.concat(onphrasing(queue))

--- a/lib/util/wrap.js
+++ b/lib/util/wrap.js
@@ -5,17 +5,22 @@
  */
 
 import extend from 'extend'
-import {phrasing as hastPhrasing} from 'hast-util-phrasing';
+import {phrasing as hastPhrasing} from 'hast-util-phrasing'
 import {phrasing as mdastPhrasing} from 'mdast-util-phrasing'
 
 /**
- * @param {MdastNode} node 
+ * @param {MdastNode} node
  * @returns {boolean}
  */
 function phrasing(node) {
   return node.data && node.data.hName
-      ? hastPhrasing({type: 'element', tagName: node.data.hName, properties: {}, children: []})
-      : mdastPhrasing(node);
+    ? hastPhrasing({
+        type: 'element',
+        tagName: node.data.hName,
+        properties: {},
+        children: []
+      })
+    : mdastPhrasing(node)
 }
 
 /**
@@ -91,7 +96,7 @@ function runs(nodes, onphrasing, onnonphrasing) {
 
     if (phrasing(node)) {
       if (!queue) queue = []
-      queue.push((/** @type {MdastPhrasingContent} */ (node)))
+      queue.push(/** @type {MdastPhrasingContent} */ (node))
     } else {
       if (queue) {
         result = result.concat(onphrasing(queue))

--- a/lib/util/wrap.js
+++ b/lib/util/wrap.js
@@ -10,7 +10,7 @@ import {phrasing as mdastPhrasing} from 'mdast-util-phrasing'
 
 /**
  * @param {MdastNode} node
- * @returns {boolean}
+ * @returns {node is MdastPhrasingContent}
  */
 function phrasing(node) {
   return node.data && node.data.hName

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "hast-util-is-element": "^2.0.0",
     "hast-util-to-text": "^3.0.0",
     "mdast-util-phrasing": "^3.0.0",
+    "hast-util-phrasing": "^2.0.1",
     "mdast-util-to-string": "^3.0.0",
     "rehype-minify-whitespace": "^5.0.0",
     "trim-trailing-lines": "^2.0.0",
@@ -54,7 +55,6 @@
   "devDependencies": {
     "@types/tape": "^4.0.0",
     "c8": "^7.0.0",
-    "hast-util-phrasing": "^2.0.1",
     "hastscript": "^7.0.0",
     "is-hidden": "^2.0.0",
     "mdast-util-assert": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@types/tape": "^4.0.0",
     "c8": "^7.0.0",
+    "hast-util-phrasing": "^2.0.1",
     "hastscript": "^7.0.0",
     "is-hidden": "^2.0.0",
     "mdast-util-assert": "^4.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -43,7 +43,7 @@ test('custom nodes', (t) => {
       },
       {type: 'text', value: ' text'}
     ]),
-    'check both hast.phrasing() with node.data.hName and mdast.phrasing()'
+    'should support `node.data.hName` to infer phrasing'
   )
 
   t.end()

--- a/test/index.js
+++ b/test/index.js
@@ -19,8 +19,28 @@ import remarkStringify from 'remark-stringify'
 import {assert} from 'mdast-util-assert'
 import {removePosition} from 'unist-util-remove-position'
 import {one, all, defaultHandlers, toMdast} from '../index.js'
+import {wrapNeeded} from '../lib/util/wrap.js'
 
 const fixtures = path.join('test', 'fixtures')
+
+test('custom nodes', (t) => {
+  t.deepEqual(
+    wrapNeeded([
+      {type: 'text', value: 'some '},
+      {
+        // @ts-ignore - custom node type
+        type: 'superscript',
+        data: {hName: 'sup'},
+        children: [{type: 'text', value: 'superscript'}]
+      },
+      {type: 'text', value: ' text'}
+    ]),
+    false,
+    'check both hast.phrasing() with node.data.hName and mdast.phrasing()'
+  )
+
+  t.end()
+})
 
 test('exports', (t) => {
   t.assert(one, 'should export `one`')

--- a/test/index.js
+++ b/test/index.js
@@ -28,7 +28,7 @@ test('custom nodes', (t) => {
     wrapNeeded([
       {type: 'text', value: 'some '},
       {
-        // @ts-ignore - custom node type
+        // @ts-expect-error - custom node type
         type: 'superscript',
         data: {hName: 'sup'},
         children: [{type: 'text', value: 'test'}]

--- a/test/index.js
+++ b/test/index.js
@@ -31,11 +31,18 @@ test('custom nodes', (t) => {
         // @ts-ignore - custom node type
         type: 'superscript',
         data: {hName: 'sup'},
-        children: [{type: 'text', value: 'superscript'}]
+        children: [{type: 'text', value: 'test'}]
       },
       {type: 'text', value: ' text'}
     ]),
-    false,
+    wrapNeeded([
+      {type: 'text', value: 'some '},
+      {
+        type: 'emphasis',
+        children: [{type: 'text', value: 'test'}]
+      },
+      {type: 'text', value: ' text'}
+    ]),
     'check both hast.phrasing() with node.data.hName and mdast.phrasing()'
   )
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [X] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [X] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [X] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [X] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [X] If applicable, I’ve added docs and tests

### Description of changes
Expand check if mdast node is phrasing content to also check node.data.tagName agains hast phrasing. This allows correct classification in conversion of hast nodes into custom mdast nodes.

#### Notes

- As per earlier [discussion](https://github.com/orgs/syntax-tree/discussions/75).
- This implementation gives priority to the hast phrasing when conflicting with mdast phrasing.
<!--do not edit: pr-->