### PR TITLE
Add support for task list checkboxes outside `p`

### DIFF
--- a/lib/handlers/li.js
+++ b/lib/handlers/li.js
@@ -17,49 +17,17 @@ import {phrasing} from 'hast-util-phrasing'
  *   mdast node.
  */
 export function li(state, node) {
-  /** @type {boolean | null} */
-  let checked = null
-  /** @type {Element | undefined} */
-  let clone
+  // If the list item starts with a checkbox, remove the checkbox and mark the
+  // list item as a GFM task list item.
+  const {cleanNode, checkbox} = extractLeadingCheckbox(node)
+  const checked = checkbox && Boolean(checkbox.properties.checked)
 
-  // Check if this node starts with a checkbox (or a paragraph that starts with
-  // a checkbox), indicating the list item is a GFM task list item.
-  let checkboxParent = node
-  let checkbox = node.children[0]
-  if (checkbox && checkbox.type === 'element' && checkbox.tagName === 'p') {
-    checkboxParent = checkbox
-    checkbox = checkbox.children[0]
-  }
-
-  if (
-    checkbox &&
-    checkbox.type === 'element' &&
-    checkbox.tagName === 'input' &&
-    checkbox.properties &&
-    (checkbox.properties.type === 'checkbox' ||
-      checkbox.properties.type === 'radio')
-  ) {
-    checked = Boolean(checkbox.properties.checked)
-
-    clone = {...node, children: [...node.children]}
-    if (checkboxParent === node) {
-      clone.children.splice(0, 1)
-    } else {
-      clone.children.splice(0, 1, {
-        ...checkboxParent,
-        children: checkboxParent.children.slice(1)
-      })
-    }
-  } else {
-    clone = node
-  }
-
-  const spread = spreadout(clone)
-  const children = state.toFlow(state.all(clone))
+  const spread = spreadout(cleanNode)
+  const children = state.toFlow(state.all(cleanNode))
 
   /** @type {ListItem} */
   const result = {type: 'listItem', spread, checked, children}
-  state.patch(clone, result)
+  state.patch(cleanNode, result)
   return result
 }
 
@@ -104,4 +72,71 @@ function spreadout(node) {
   }
 
   return false
+}
+
+/**
+ * If the first bit of content in an element is a checkbox, create a copy of
+ * the element that does not include the checkbox and return the cleaned up
+ * copy alongside the checkbox that was removed. If there was no leading
+ * checkbox, this returns the original element unaltered (not a copy).
+ *
+ * This detects trees like:
+ *   `<li><input type="checkbox">Text</li>`
+ * And returns a tree like:
+ *   `<li>Text</li>`
+ *
+ * Or with nesting:
+ *   `<li><p><input type="checkbox">Text</p></li>`
+ * Which returns a tree like:
+ *   `<li><p>Text</p></li>`
+ *
+ * @param {Readonly<Element>} node
+ * @returns {{cleanNode: Element, checkbox: Element | null}}
+ */
+function extractLeadingCheckbox(node) {
+  /** @type {Element | null} */
+  let checkbox = null
+  let cleanNode = node
+  let candidate = node.children[0]
+
+  // The checkbox may be nested in another container element, so keep track of
+  // what node actually contains the potential checkbox.
+  //
+  // NOTE: this only handles nesting in `<p>` elements, which is most common.
+  // It's possible a leading checkbox might be nested in other types of flow or
+  // phrasing elements (and *deeply* nested, which is not possible with `<p>`).
+  // Limiting things to `<p>` elements keeps it simpler for now.
+  let checkboxParent = node
+  if (candidate && candidate.type === 'element' && candidate.tagName === 'p') {
+    checkboxParent = candidate
+    candidate = candidate.children[0]
+  }
+
+  if (
+    candidate &&
+    candidate.type === 'element' &&
+    candidate.tagName === 'input' &&
+    candidate.properties &&
+    (candidate.properties.type === 'checkbox' ||
+      candidate.properties.type === 'radio')
+  ) {
+    checkbox = candidate
+
+    // The checkbox is a direct child of `node`.
+    if (checkboxParent === node) {
+      cleanNode = {...node, children: node.children.slice(1)}
+    }
+    // The checkbox is nested in another child (which is `checkboxParent`).
+    else {
+      cleanNode = {
+        ...node,
+        children: [
+          {...checkboxParent, children: checkboxParent.children.slice(1)},
+          ...node.children.slice(1)
+        ]
+      }
+    }
+  }
+
+  return {cleanNode, checkbox}
 }

--- a/lib/handlers/li.js
+++ b/lib/handlers/li.js
@@ -23,7 +23,7 @@ export function li(state, node) {
   let clone
 
   // Check if this node starts with a checkbox (or a paragraph that starts with
-  // a checkbox), indicating the list item is a GFM TaskListItem.
+  // a checkbox), indicating the list item is a GFM task list item.
   let checkboxParent = node
   let checkbox = node.children[0]
   if (checkbox && checkbox.type === 'element' && checkbox.tagName === 'p') {

--- a/lib/handlers/li.js
+++ b/lib/handlers/li.js
@@ -94,49 +94,40 @@ function spreadout(node) {
  * @returns {{cleanNode: Element, checkbox: Element | null}}
  */
 function extractLeadingCheckbox(node) {
-  /** @type {Element | null} */
-  let checkbox = null
-  let cleanNode = node
-  let candidate = node.children[0]
+  const head = node.children[0]
 
-  // The checkbox may be nested in another container element, so keep track of
-  // what node actually contains the potential checkbox.
+  if (
+    head &&
+    head.type === 'element' &&
+    head.tagName === 'input' &&
+    head.properties &&
+    (head.properties.type === 'checkbox' || head.properties.type === 'radio')
+  ) {
+    return {
+      cleanNode: {...node, children: node.children.slice(1)},
+      checkbox: head
+    }
+  }
+
+  // The checkbox may be nested in another element. If the first element has
+  // children, look for a leading checkbox inside it.
   //
   // NOTE: this only handles nesting in `<p>` elements, which is most common.
   // It's possible a leading checkbox might be nested in other types of flow or
   // phrasing elements (and *deeply* nested, which is not possible with `<p>`).
-  // Limiting things to `<p>` elements keeps it simpler for now.
-  let checkboxParent = node
-  if (candidate && candidate.type === 'element' && candidate.tagName === 'p') {
-    checkboxParent = candidate
-    candidate = candidate.children[0]
-  }
-
-  if (
-    candidate &&
-    candidate.type === 'element' &&
-    candidate.tagName === 'input' &&
-    candidate.properties &&
-    (candidate.properties.type === 'checkbox' ||
-      candidate.properties.type === 'radio')
-  ) {
-    checkbox = candidate
-
-    // The checkbox is a direct child of `node`.
-    if (checkboxParent === node) {
-      cleanNode = {...node, children: node.children.slice(1)}
-    }
-    // The checkbox is nested in another child (which is `checkboxParent`).
-    else {
-      cleanNode = {
-        ...node,
-        children: [
-          {...checkboxParent, children: checkboxParent.children.slice(1)},
-          ...node.children.slice(1)
-        ]
+  // Limiting things to `<p>` elements keeps this simpler for now.
+  if (head && head.type === 'element' && head.tagName === 'p') {
+    const {cleanNode: cleanHead, checkbox} = extractLeadingCheckbox(head)
+    if (checkbox) {
+      return {
+        cleanNode: {
+          ...node,
+          children: [cleanHead, ...node.children.slice(1)]
+        },
+        checkbox
       }
     }
   }
 
-  return {cleanNode, checkbox}
+  return {cleanNode: node, checkbox: null}
 }

--- a/lib/handlers/li.js
+++ b/lib/handlers/li.js
@@ -17,36 +17,42 @@ import {phrasing} from 'hast-util-phrasing'
  *   mdast node.
  */
 export function li(state, node) {
-  const head = node.children[0]
   /** @type {boolean | null} */
   let checked = null
   /** @type {Element | undefined} */
   let clone
 
-  // Check if this node starts with a checkbox.
-  if (head && head.type === 'element' && head.tagName === 'p') {
-    const checkbox = head.children[0]
-
-    if (
-      checkbox &&
-      checkbox.type === 'element' &&
-      checkbox.tagName === 'input' &&
-      checkbox.properties &&
-      (checkbox.properties.type === 'checkbox' ||
-        checkbox.properties.type === 'radio')
-    ) {
-      checked = Boolean(checkbox.properties.checked)
-      clone = {
-        ...node,
-        children: [
-          {...head, children: head.children.slice(1)},
-          ...node.children.slice(1)
-        ]
-      }
-    }
+  // Check if this node starts with a checkbox (or a paragraph that starts with
+  // a checkbox), indicating the list item is a GFM TaskListItem.
+  let checkboxParent = node
+  let checkbox = node.children[0]
+  if (checkbox && checkbox.type === 'element' && checkbox.tagName === 'p') {
+    checkboxParent = checkbox
+    checkbox = checkbox.children[0]
   }
 
-  if (!clone) clone = node
+  if (
+    checkbox &&
+    checkbox.type === 'element' &&
+    checkbox.tagName === 'input' &&
+    checkbox.properties &&
+    (checkbox.properties.type === 'checkbox' ||
+      checkbox.properties.type === 'radio')
+  ) {
+    checked = Boolean(checkbox.properties.checked)
+
+    clone = {...node, children: [...node.children]}
+    if (checkboxParent === node) {
+      clone.children.splice(0, 1)
+    } else {
+      clone.children.splice(0, 1, {
+        ...checkboxParent,
+        children: checkboxParent.children.slice(1)
+      })
+    }
+  } else {
+    clone = node
+  }
 
   const spread = spreadout(clone)
   const children = state.toFlow(state.all(clone))

--- a/test/fixtures/ol/index.html
+++ b/test/fixtures/ol/index.html
@@ -68,4 +68,5 @@
   <li>
     <input type="checkbox"> Juliet
   </li>
+  <li><input type="checkbox"></li>
 </ol>

--- a/test/fixtures/ol/index.html
+++ b/test/fixtures/ol/index.html
@@ -59,4 +59,13 @@
   <li><p><input type="checkbox">Echo</p></li>
   <li><p><input type="checkbox"><strong>Foxtrot</strong></p></li>
   <li><p><input type="checkbox"> <strong>Golf</strong></p></li>
+  <li>
+    <p>
+      <input type="checkbox"> Hotel
+    </p>
+  </li>
+  <li><input type="checkbox"> India</li>
+  <li>
+    <input type="checkbox"> Juliet
+  </li>
 </ol>

--- a/test/fixtures/ol/index.md
+++ b/test/fixtures/ol/index.md
@@ -57,3 +57,9 @@ Quuux.
 5. [ ] **Foxtrot**
 
 6. [ ] **Golf**
+
+7. [ ] Hotel
+
+8. [ ] India
+
+9. [ ] Juliet

--- a/test/fixtures/ol/index.md
+++ b/test/fixtures/ol/index.md
@@ -63,3 +63,5 @@ Quuux.
 8. [ ] India
 
 9. [ ] Juliet
+
+10.

--- a/test/fixtures/ul/index.html
+++ b/test/fixtures/ul/index.html
@@ -68,4 +68,5 @@
   <li>
     <input type="checkbox"> Juliet
   </li>
+  <li><input type="checkbox"></li>
 </ul>

--- a/test/fixtures/ul/index.html
+++ b/test/fixtures/ul/index.html
@@ -59,4 +59,13 @@
   <li><p><input type="checkbox">Echo</p></li>
   <li><p><input type="checkbox"><strong>Foxtrot</strong></p></li>
   <li><p><input type="checkbox"> <strong>Golf</strong></p></li>
+  <li>
+    <p>
+      <input type="checkbox"> Hotel
+    </p>
+  </li>
+  <li><input type="checkbox"> India</li>
+  <li>
+    <input type="checkbox"> Juliet
+  </li>
 </ul>

--- a/test/fixtures/ul/index.md
+++ b/test/fixtures/ul/index.md
@@ -57,3 +57,9 @@ Quuux.
 * [ ] **Foxtrot**
 
 * [ ] **Golf**
+
+* [ ] Hotel
+
+* [ ] India
+
+* [ ] Juliet

--- a/test/fixtures/ul/index.md
+++ b/test/fixtures/ul/index.md
@@ -63,3 +63,5 @@ Quuux.
 * [ ] India
 
 * [ ] Juliet
+
+*


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Previously, list items with leading checkboxes would only be treated as task list items if the checkbox was wrapped in a `<p>` element, like:

```html
<li><p><input type="checkbox"> Other content</p></li>
```

This adds support for detecting task lists even when the checkbox is not nested in a `<p>`:

```html
<li><input type="checkbox"> Other content</li>
```

This does *not* add support for some other complex scenarios, such as the checkbox being inside other phrasing content, being more deeply nested, or having comments in front of it, since the implementation gets much more complex:

```html
<li><strong><input type="checkbox"> Other content</strong></li>
<li><p><strong><input type="checkbox"> Other content</strong></p></li>
<li><!-- Comment --><input type="checkbox"> Other content</li>
```

See discussion on #80 for more about that. There is a prototype of support for deeper nesting, but not comments, at https://github.com/Mr0grog/hast-util-to-mdast/commit/9a386bc9ec35e2d6226d1d877f880d6f5d17c0f0, which I am happy to add here (or clean up some) if you like it.

Fixes #80.

### Side Questions

1. I thought about writing some kind of warning messages for situations that are probably malformed, e.g. there is a leading checkbox, but followed by non-phrasing content (so you’d wind up with a Mdast tree that is in some sense invalid, or at least doesn’t stringify correctly). I was thinking of the error messages in remark-parse’s `emitErrors` option (obviously not exactly the same since this is not a Unified plugin). Anyway, I didn’t see tooling for anything like this, and wanted to make sure I wasn’t missing it.

2. I couldn’t find an easy/obvious way to narrow down which tests were running, which would have been helpful while debugging some issues (instead, I wound up hacking around in the `test/index.js` file). Is there a way to do this that I’m missing? Otherwise it seems like [the Node.js test runner has support](https://nodejs.org/dist/latest-v18.x/docs/api/test.html#filtering-tests-by-name), but the way tests are run and written here doesn’t work with it:
    - Need to run tests with `node --test`, not `node test/index.js` (i.e. don’t run an actual test file), then you can use `--test-name-pattern` to filter tests.
    - Need to define test suites with `describe()` and `it()` instead of `test()` with subtests. I think the issue with the latter is that it can’t know in advance whether you are defining subtests, so it can’t filter based on them.

    ^^ If those are useful changes, I’m happy to do a separate, quick PR for them.

<!--do not edit: pr-->
